### PR TITLE
fix path to run server

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -2,4 +2,4 @@
 
 set -e
 
-/usr/bin/xvfb-run --server-num=1 /usr/bin/spawn-fcgi -p 5000 -n -d /data -- /opt/qgis/bin/qgis_mapserv.fcgi
+/usr/bin/xvfb-run --server-num=1 /usr/bin/spawn-fcgi -p 5000 -n -d /data -- /usr/bin/qgis_mapserv.fcgi


### PR DESCRIPTION
The path in `run.sh` script was wrong. Thats why the server was never coming up. At least the version I tried not: `ghcr.io/opengisch/qgis-slim:3.34.8`

You can try it yourself: `docker run --rm ghcr.io/opengisch/qgis-slim:3.34.8`